### PR TITLE
GHA ubuntu 20.04 build fixes.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -149,6 +149,21 @@ jobs:
             sudo apt install cmake g++ zip libgl-dev libssl-dev
 
             sudo apt install qt5153d qt5153d-dbg qt515base qt515base-dbg qt515charts-no-lgpl qt515connectivity qt515connectivity-dbg qt515datavis3d-no-lgpl qt515declarative qt515declarative-dbg qt515doc qt515gamepad qt515graphicaleffects qt515graphicaleffects-dbg qt515imageformats qt515imageformats-dbg qt515location qt515location-dbg qt515lottie-no-lgpl qt515multimedia qt515multimedia-dbg qt515networkauth-no-lgpl qt515opcua qt515opcua-dbg qt515quick3d-no-lgpl qt515quickcontrols qt515quickcontrols-dbg qt515quickcontrols2 qt515quickcontrols2-dbg qt515quicktimeline-no-lgpl qt515remoteobjects qt515remoteobjects-dbg qt515script qt515script-dbg qt515scxml qt515scxml-dbg qt515sensors qt515sensors-dbg qt515serialbus qt515serialbus-dbg qt515serialport qt515serialport-dbg qt515speech qt515speech-dbg qt515svg qt515svg-dbg qt515tools qt515tools-dbg qt515translations qt515wayland qt515wayland-dbg qt515webchannel qt515webchannel-dbg qt515webengine qt515webengine-dbg qt515webglplugin-no-lgpl qt515websockets qt515websockets-dbg qt515x11extras qt515x11extras-dbg qt515xmlpatterns qt515xmlpatterns-dbg
+
+            strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+            sudo df -h
+
+            # attempt to free up space
+            sudo swapoff -a
+            sudo rm -f /swapfile
+            sudo apt clean
+            docker rmi $(docker image ls -aq)
+
+            # downgrade libstdc++6 to what is normal for Ubuntu 20.04
+            sudo apt-get install --allow-downgrades --no-remove --reinstall -y libstdc++6=10.5.0-1ubuntu1~20.04
+
+            strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+            sudo df -h
           fi
 
         else # macOS

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -174,6 +174,7 @@ jobs:
             sudo apt install qt5153d qt5153d-dbg qt515base qt515base-dbg qt515charts-no-lgpl qt515connectivity qt515connectivity-dbg qt515datavis3d-no-lgpl qt515declarative qt515declarative-dbg qt515doc qt515gamepad qt515graphicaleffects qt515graphicaleffects-dbg qt515imageformats qt515imageformats-dbg qt515location qt515location-dbg qt515lottie-no-lgpl qt515multimedia qt515multimedia-dbg qt515networkauth-no-lgpl qt515opcua qt515opcua-dbg qt515quick3d-no-lgpl qt515quickcontrols qt515quickcontrols-dbg qt515quickcontrols2 qt515quickcontrols2-dbg qt515quicktimeline-no-lgpl qt515remoteobjects qt515remoteobjects-dbg qt515script qt515script-dbg qt515scxml qt515scxml-dbg qt515sensors qt515sensors-dbg qt515serialbus qt515serialbus-dbg qt515serialport qt515serialport-dbg qt515speech qt515speech-dbg qt515svg qt515svg-dbg qt515tools qt515tools-dbg qt515translations qt515wayland qt515wayland-dbg qt515webchannel qt515webchannel-dbg qt515webengine qt515webengine-dbg qt515webglplugin-no-lgpl qt515websockets qt515websockets-dbg qt515x11extras qt515x11extras-dbg qt515xmlpatterns qt515xmlpatterns-dbg
 
             strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+            which g++-11 || which g++-12 || true
           fi
 
         else # macOS

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -172,6 +172,8 @@ jobs:
             sudo apt install cmake g++ zip libgl-dev libssl-dev
 
             sudo apt install qt5153d qt5153d-dbg qt515base qt515base-dbg qt515charts-no-lgpl qt515connectivity qt515connectivity-dbg qt515datavis3d-no-lgpl qt515declarative qt515declarative-dbg qt515doc qt515gamepad qt515graphicaleffects qt515graphicaleffects-dbg qt515imageformats qt515imageformats-dbg qt515location qt515location-dbg qt515lottie-no-lgpl qt515multimedia qt515multimedia-dbg qt515networkauth-no-lgpl qt515opcua qt515opcua-dbg qt515quick3d-no-lgpl qt515quickcontrols qt515quickcontrols-dbg qt515quickcontrols2 qt515quickcontrols2-dbg qt515quicktimeline-no-lgpl qt515remoteobjects qt515remoteobjects-dbg qt515script qt515script-dbg qt515scxml qt515scxml-dbg qt515sensors qt515sensors-dbg qt515serialbus qt515serialbus-dbg qt515serialport qt515serialport-dbg qt515speech qt515speech-dbg qt515svg qt515svg-dbg qt515tools qt515tools-dbg qt515translations qt515wayland qt515wayland-dbg qt515webchannel qt515webchannel-dbg qt515webengine qt515webengine-dbg qt515webglplugin-no-lgpl qt515websockets qt515websockets-dbg qt515x11extras qt515x11extras-dbg qt515xmlpatterns qt515xmlpatterns-dbg
+
+            strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
           fi
 
         else # macOS

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -182,7 +182,7 @@ jobs:
             sudo apt clean
             docker rmi $(docker image ls -aq)
 
-            # downgrade libstdc++6 to what is normal for ubuntu20.04
+            # downgrade libstdc++6 to what is normal for Ubuntu 20.04
             sudo apt-get install --allow-downgrades --no-remove --reinstall -y libstdc++6=10.5.0-1ubuntu1~20.04
 
             strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -174,7 +174,19 @@ jobs:
             sudo apt install qt5153d qt5153d-dbg qt515base qt515base-dbg qt515charts-no-lgpl qt515connectivity qt515connectivity-dbg qt515datavis3d-no-lgpl qt515declarative qt515declarative-dbg qt515doc qt515gamepad qt515graphicaleffects qt515graphicaleffects-dbg qt515imageformats qt515imageformats-dbg qt515location qt515location-dbg qt515lottie-no-lgpl qt515multimedia qt515multimedia-dbg qt515networkauth-no-lgpl qt515opcua qt515opcua-dbg qt515quick3d-no-lgpl qt515quickcontrols qt515quickcontrols-dbg qt515quickcontrols2 qt515quickcontrols2-dbg qt515quicktimeline-no-lgpl qt515remoteobjects qt515remoteobjects-dbg qt515script qt515script-dbg qt515scxml qt515scxml-dbg qt515sensors qt515sensors-dbg qt515serialbus qt515serialbus-dbg qt515serialport qt515serialport-dbg qt515speech qt515speech-dbg qt515svg qt515svg-dbg qt515tools qt515tools-dbg qt515translations qt515wayland qt515wayland-dbg qt515webchannel qt515webchannel-dbg qt515webengine qt515webengine-dbg qt515webglplugin-no-lgpl qt515websockets qt515websockets-dbg qt515x11extras qt515x11extras-dbg qt515xmlpatterns qt515xmlpatterns-dbg
 
             strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
-            which g++-11 || which g++-12 || true
+            sudo df -h
+
+            # attempt to free up space
+            sudo swapoff -a
+            sudo rm -f /swapfile
+            sudo apt clean
+            docker rmi $(docker image ls -aq)
+
+            # downgrade libstdc++6 to what is normal for ubuntu20.04
+            sudo apt-get install --allow-downgrades --no-remove --reinstall -y libstdc++6=10.5.0-1ubuntu1~20.04
+
+            strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX
+            sudo df -h
           fi
 
         else # macOS


### PR DESCRIPTION
The GHA runner was running out of disk space, and also at some point upgraded the C++ standard library to a version that is not available in plain Ubuntu 20.04. Workarounds taken from https://github.com/jens-maus/RaspberryMatic/blob/d5044bef3307bc61166377c162569de1a61cf332/.github/workflows/ci.yml#L34-L40 and https://github.com/actions/runner-images/issues/3432. If Github fixes these issues in the future the workaround might fail and would need to be removed, but reading through some similar issues I've found I'm not sure what their stance on this is. 