### PR TITLE
Workaround for GHA Ubuntu 20.04 grub-efi-amd64-signed package issue.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -134,6 +134,9 @@ jobs:
           echo "Installing Python Modules:"
           pip3 install distro || exit 1
 
+          # workaround https://github.com/orgs/community/discussions/47863
+          sudo apt-mark hold grub-efi-amd64-signed
+
           echo "Updating apt repository index"
           sudo apt update || exit 1
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -157,6 +157,9 @@ jobs:
           echo "Installing Python Modules:"
           pip3 install distro || exit 1
 
+          # workaround https://github.com/orgs/community/discussions/47863
+          sudo apt-mark hold grub-efi-amd64-signed
+
           echo "Updating apt repository index"
           sudo apt update || exit 1
 


### PR DESCRIPTION
https://github.com/orgs/community/discussions/47863